### PR TITLE
Refactor Power Factor Heatpump sensor definition

### DIFF
--- a/custom_components/comfoclime/entities/sensor_definitions.py
+++ b/custom_components/comfoclime/entities/sensor_definitions.py
@@ -297,11 +297,7 @@ CONNECTED_DEVICE_SENSORS = {
             "name": "Power Factor Heatpump",
             "translation_key": "powerfactor_heatpump",
             "unit": "%",
-            "device_class": "power_factor",
             "state_class": "measurement",
-            "byte_count": 1,
-            "signed": False,
-            "diagnose": True,
         },
         {
             "telemetry_id": 4201,


### PR DESCRIPTION
Removed device_class and other attributes from Power Factor Heatpump sensor definition.