### PR TITLE
fix: Betriebsdauer-Sensor liefert Bootzeitpunkt statt Sekunden

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,13 @@ mitziehen, sonst installiert HACS die Integration auf eine HA, auf der sie nicht
 - Der Options-Flow enthält **absichtlich** keine Entity-Auswahl (Abschnitt 6). Bug-Reports wie
   „Sensor X fehlt“ sind fast immer eine in der Registry deaktivierte Entity, kein fehlender
   Sensor – zuerst auf der Geräteseite unter „+N Entitäten deaktiviert“ nachsehen.
+- **`SensorDeviceClass.UPTIME` ist keine Zahl.** HA erwartet dort den Zeitpunkt des letzten
+  Neustarts als *aware* `datetime` (ISO 8601), keine Sekunden – sonst wirft der Sensor beim
+  Schreiben des States `AttributeError: 'int' object has no attribute 'tzinfo'`, der im Coordinator
+  als „Unexpected error updating listener …“ landet. `/monitoring/ping` liefert Sekunden plus den
+  Geräte-Zeitstempel; `models.uptime_to_boot_time()` rechnet daraus den Bootzeitpunkt (Anker =
+  Geräteuhr, bei mehr als einer Stunde Abweichung stattdessen die HA-Uhr). Die Device-Class erlaubt
+  außerdem weder `unit` noch `state_class`; Drift zwischen Abfragen glättet HA selbst (60 s).
 - Reauth-Flow ist bewusst **nicht** implementiert – die Geräte-API kennt keine Authentifizierung
   und keine Auth-Fehler. Nur relevant, falls Zehnder das per Firmware-Update ändert.
 - **GitHub-Integration-Timeout-Fehler** (`homeassistant.components.github`, `Timeout of 20 reached

--- a/custom_components/comfoclime/entities/sensor_definitions.py
+++ b/custom_components/comfoclime/entities/sensor_definitions.py
@@ -261,12 +261,15 @@ DASHBOARD_SENSORS = [
 ]
 
 MONITORING_SENSORS = [
+    # Der Schlüssel bleibt bewusst "up_time_seconds" (Rohwert der API und Teil der
+    # unique_id); der Sensor rechnet ihn für die UPTIME-Device-Class in den
+    # Zeitpunkt des letzten Neustarts um. Diese Device-Class ist nicht numerisch,
+    # daher weder unit noch state_class.
     SensorDefinition(
         key="up_time_seconds",
         name="Uptime",
         translation_key="uptime",
         device_class=SensorDeviceClass.UPTIME,
-        state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category="diagnostic",
     ),
 ]

--- a/custom_components/comfoclime/models.py
+++ b/custom_components/comfoclime/models.py
@@ -7,7 +7,7 @@ byte conversion and temperature value processing.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -144,6 +144,47 @@ def fix_signed_temperatures_in_dict(data: dict) -> dict:
         elif "Temperature" in key and val is not None and isinstance(val, (int, float)):
             data[key] = fix_signed_temperature(val)
     return data
+
+
+# Weicht die Geräteuhr weiter als das von der Systemzeit ab, ist sie nicht
+# synchronisiert, dann ankert die Home-Assistant-Zeit den Bootzeitpunkt.
+MAX_DEVICE_CLOCK_SKEW = timedelta(hours=1)
+
+
+def uptime_to_boot_time(up_time_seconds: float | None, device_timestamp: float | None = None) -> datetime | None:
+    """Convert an uptime in seconds to the point in time the device booted.
+
+    ``SensorDeviceClass.UPTIME`` expects a timezone-aware datetime of the last
+    restart, but the device reports the elapsed seconds instead. The device also
+    sends its own clock in ``/monitoring/ping``; using that as the anchor keeps
+    the derived boot time stable across polls, because both values come from the
+    same device tick. If the device clock is off (unsynchronized or unparsable),
+    the local clock is used instead: the elapsed duration is what matters.
+
+    Args:
+        up_time_seconds: Seconds since the device booted.
+        device_timestamp: Unix timestamp reported by the device, if available.
+
+    Returns:
+        Timezone-aware UTC datetime of the last restart, or ``None`` if no
+        uptime was reported.
+
+    Example:
+        >>> boot_time = uptime_to_boot_time(3600, int(datetime.now(UTC).timestamp()))
+        >>> (datetime.now(UTC) - boot_time).total_seconds() >= 3600
+        True
+    """
+    if up_time_seconds is None or not isinstance(up_time_seconds, (int, float)):
+        return None
+
+    now = datetime.now(UTC)
+    anchor = now
+    if isinstance(device_timestamp, (int, float)):
+        device_now = datetime.fromtimestamp(device_timestamp, tz=UTC)
+        if abs(device_now - now) <= MAX_DEVICE_CLOCK_SKEW:
+            anchor = device_now
+
+    return anchor - timedelta(seconds=up_time_seconds)
 
 
 class DeviceConfig(ComfoClimeModel):
@@ -671,6 +712,15 @@ class MonitoringPing(ComfoClimeModel):
                     # Remove invalid timestamp to avoid validation error
                     v.pop("timestamp", None)
         return v
+
+    @property
+    def boot_time(self) -> datetime | None:
+        """Point in time the device last restarted (UTC).
+
+        Derived from ``up_time_seconds`` and the device timestamp; this is what
+        ``SensorDeviceClass.UPTIME`` expects, the raw second count is not.
+        """
+        return uptime_to_boot_time(self.up_time_seconds, self.timestamp)
 
 
 class PropertyWriteRequest(ComfoClimeModel):

--- a/custom_components/comfoclime/sensor.py
+++ b/custom_components/comfoclime/sensor.py
@@ -73,6 +73,7 @@ from .entity_helper import (
     get_device_model_type_id,
     get_device_uuid,
 )
+from .models import uptime_to_boot_time
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -326,8 +327,14 @@ class ComfoClimeSensor(ComfoClimeBaseEntity, CoordinatorEntity, SensorEntity):
 
             self._raw_value = raw_value
 
+            # Die Geräte-API liefert Sekunden seit dem Start, Home Assistant
+            # erwartet für diese Device-Class den Zeitpunkt des letzten Neustarts
+            # als aware datetime (siehe models.uptime_to_boot_time).
+            if self._attr_device_class is SensorDeviceClass.UPTIME:
+                timestamp = data.get("timestamp") if isinstance(data, dict) else getattr(data, "timestamp", None)
+                self._state = uptime_to_boot_time(raw_value, timestamp)
             # Wenn es eine definierte Übersetzung gibt, wende sie an
-            if self._type in VALUE_MAPPINGS:
+            elif self._type in VALUE_MAPPINGS:
                 self._state = VALUE_MAPPINGS[self._type].get(raw_value, raw_value)
             else:
                 self._state = raw_value

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,7 @@
 """Tests for data models in models.py"""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from pydantic import ValidationError
 
@@ -27,6 +29,7 @@ from custom_components.comfoclime.models import (
     fix_signed_temperature,
     fix_signed_temperatures_in_dict,
     signed_int_to_bytes,
+    uptime_to_boot_time,
 )
 
 
@@ -776,6 +779,87 @@ class TestMonitoringPing:
 
         with pytest.raises(ValidationError):
             ping.uuid = "new-uuid"
+
+    def test_monitoring_ping_invalid_timestamp_string(self):
+        """Test that invalid timestamp string is removed (set to None)."""
+        # Invalid timestamp should be removed to avoid validation error
+        ping = MonitoringPing(
+            uuid="test-uuid",
+            up_time_seconds=123456,
+            timestamp="invalid-timestamp",
+        )
+
+        assert ping.uuid == "test-uuid"
+        assert ping.up_time_seconds == 123456
+        # Invalid timestamp should be removed
+        assert ping.timestamp is None
+
+    def test_boot_time_uses_device_timestamp(self):
+        """Boot time is anchored to the device clock when it is plausible."""
+        device_now = datetime.now(UTC).replace(microsecond=0)
+        ping = MonitoringPing(
+            uuid="test-uuid",
+            up_time_seconds=3600,
+            timestamp=int(device_now.timestamp()),
+        )
+
+        assert ping.boot_time == device_now - timedelta(hours=1)
+
+    def test_boot_time_falls_back_to_local_clock(self):
+        """A missing device timestamp still yields an aware boot time."""
+        ping = MonitoringPing(uuid="test-uuid", up_time_seconds=3600)
+
+        boot_time = ping.boot_time
+
+        assert boot_time is not None
+        assert boot_time.tzinfo is not None
+        assert abs(datetime.now(UTC) - boot_time - timedelta(hours=1)) < timedelta(seconds=5)
+
+    def test_boot_time_without_uptime(self):
+        """Without an uptime there is nothing to derive."""
+        assert MonitoringPing(uuid="test-uuid", timestamp=1705314600).boot_time is None
+
+
+class TestUptimeToBootTime:
+    """Tests for the uptime -> boot time conversion (SensorDeviceClass.UPTIME)."""
+
+    def test_returns_aware_datetime(self):
+        """The result must carry timezone info, HA rejects naive datetimes."""
+        device_now = datetime.now(UTC).replace(microsecond=0)
+
+        boot_time = uptime_to_boot_time(120, int(device_now.timestamp()))
+
+        assert boot_time == device_now - timedelta(seconds=120)
+        assert boot_time.tzinfo is not None
+
+    def test_stable_across_polls(self):
+        """Device timestamp and uptime advance together, boot time stays put."""
+        device_now = int(datetime.now(UTC).timestamp())
+
+        first = uptime_to_boot_time(100, device_now)
+        later = uptime_to_boot_time(160, device_now + 60)
+
+        assert first == later
+
+    def test_implausible_device_clock_uses_local_time(self):
+        """An unsynchronized device clock must not shift the boot time."""
+        # Device claims it is 2001 - fall back to the local clock instead.
+        boot_time = uptime_to_boot_time(60, 1000000000)
+
+        assert abs(datetime.now(UTC) - boot_time - timedelta(seconds=60)) < timedelta(seconds=5)
+
+    def test_invalid_values_return_none(self):
+        """Missing or non-numeric uptimes have no boot time."""
+        device_now = int(datetime.now(UTC).timestamp())
+
+        assert uptime_to_boot_time(None, device_now) is None
+        assert uptime_to_boot_time("unknown", device_now) is None
+
+    def test_invalid_device_timestamp_is_ignored(self):
+        """A non-numeric device timestamp falls back to the local clock."""
+        boot_time = uptime_to_boot_time(60, "not-a-timestamp")
+
+        assert abs(datetime.now(UTC) - boot_time - timedelta(seconds=60)) < timedelta(seconds=5)
 
     def test_monitoring_ping_invalid_timestamp_string(self):
         """Test that invalid timestamp string is removed (set to None)."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for ComfoClime sensor entities."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -110,13 +110,18 @@ class TestComfoClimeSensor:
         assert device_info["manufacturer"] == "Zehnder"
 
     def test_monitoring_sensor_update(self, mock_hass, mock_config_entry):
-        """Test monitoring sensor state update from MonitoringPing coordinator."""
+        """Test monitoring sensor state update from MonitoringPing coordinator.
+
+        The uptime device class needs the point in time of the last restart, so
+        the raw second count from the device is converted to an aware datetime.
+        """
         # Create a mock monitoring coordinator with MonitoringPing data
+        device_now = datetime.now(UTC).replace(microsecond=0)
         mock_monitoring_coordinator = MagicMock()
         mock_monitoring_coordinator.data = MonitoringPing(
             uuid="test-uuid",
             up_time_seconds=123456,
-            timestamp=1705314600,
+            timestamp=int(device_now.timestamp()),
         )
         mock_monitoring_coordinator.last_update_success_time = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
 
@@ -129,7 +134,7 @@ class TestComfoClimeSensor:
             translation_key="uptime",
             unit=None,
             device_class="uptime",
-            state_class="total_increasing",
+            state_class=None,
             entity_category="diagnostic",
             device=None,
             entry=mock_config_entry,
@@ -142,10 +147,11 @@ class TestComfoClimeSensor:
         # Trigger coordinator update
         sensor._handle_coordinator_update()
 
-        # Verify the sensor correctly retrieved the uptime value
-        assert sensor._state == 123456
+        # The raw value stays available as an attribute, the state is the boot time
         assert sensor._raw_value == 123456
-        assert sensor.native_value == 123456
+        assert sensor.native_value == device_now - timedelta(seconds=123456)
+        assert sensor.native_value.tzinfo is not None
+        assert sensor.extra_state_attributes["raw_value"] == 123456
 
     def test_sensor_extra_state_attributes_dashboard(
         self, mock_hass, mock_coordinator, mock_api, mock_device, mock_config_entry

--- a/tests/test_sensor_definitions.py
+++ b/tests/test_sensor_definitions.py
@@ -454,8 +454,9 @@ class TestMonitoringSensorDefinitions:
         assert uptime_sensor.device_class == "uptime", (
             "SensorDeviceClass.UPTIME requires Home Assistant >= 2026.5.0; see hacs.json."
         )
-        assert uptime_sensor.state_class == "total_increasing", (
-            "Uptime sensor must use total_increasing state class since it only increases."
+        assert uptime_sensor.state_class is None, (
+            "The uptime device class is a point in time, not a measurement: "
+            "Home Assistant allows no state class for it."
         )
         assert uptime_sensor.entity_category == "diagnostic"
 


### PR DESCRIPTION
## Problem

Der Betriebsdauer-Sensor (`SensorDeviceClass.UPTIME`) schrieb den Rohwert der API – einen `int` mit Sekunden seit dem Start. Home Assistant erwartet für diese Device-Class aber einen zeitzonenbehafteten `datetime` (Zeitpunkt des letzten Neustarts, ISO 8601). Jeder State-Write scheiterte deshalb:

```
ValueError: Invalid datetime: sensor.comfoclime_24_betriebsdauer has uptime device class
but provides state 49032:<class 'int'> resulting in ''int' object has no attribute 'tzinfo''
```

Im Log tauchte das pro Coordinator-Refresh als `Unexpected error updating listener … for ComfoClime Monitoring` auf.

## Änderungen

- **`models.uptime_to_boot_time()`** (neu): rechnet Uptime-Sekunden in den Bootzeitpunkt um. `/monitoring/ping` liefert neben der Uptime auch die Geräteuhr – die dient als Anker, damit der abgeleitete Zeitpunkt über alle Abfragen hinweg stabil bleibt (beide Werte stammen aus demselben Geräte-Tick). Ist die Geräteuhr unplausibel (mehr als eine Stunde Abweichung) oder nicht parsbar, ankert die HA-Uhr; die verstrichene Dauer bleibt so in jedem Fall korrekt.
- **`MonitoringPing.boot_time`**: Property, die dieselbe Umrechnung auf dem Modell anbietet.
- **`ComfoClimeSensor._handle_coordinator_update()`**: wandelt den Wert um, sobald die Device-Class `UPTIME` ist. Der Sekundenwert bleibt als Attribut `raw_value` sichtbar.
- **`MONITORING_SENSORS`**: `state_class` entfernt – die UPTIME-Device-Class ist nicht numerisch und erlaubt weder Unit noch State-Class. Der Key bleibt bewusst `up_time_seconds`, damit die `unique_id` und damit die bestehende Entity erhalten bleibt. Drift zwischen Abfragen glättet HA selbst (Toleranz 60 s).
- `CLAUDE.md`: Fallstrick dokumentiert.

## Tests

- `tests/test_models.py`: neue Klasse `TestUptimeToBootTime` (Anker Geräteuhr, Stabilität über mehrere Abfragen, Fallback bei unplausibler/ungültiger Geräteuhr, `None`-Fälle) plus `boot_time`-Tests an `MonitoringPing`.
- `tests/test_sensor.py`: Monitoring-Sensor prüft jetzt den aware `datetime` als State und den Sekundenwert im Attribut.
- `tests/test_sensor_definitions.py`: erwartet keine `state_class` mehr.

⚠️ Die Testsuite konnte in dieser Umgebung nicht ausgeführt werden – es gibt keinen Interpreter ≥ 3.14.2 (nur 3.14.0rc2 wäre installierbar), den `pyproject.toml` verlangt. Geprüft wurden `ruff check` und `ruff format --check` (beide sauber) sowie die Logik von `uptime_to_boot_time()` gegen alle neuen Testfälle in einem isolierten Skript.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUiitjx4HMkJdJeXYgh5iz)_